### PR TITLE
Feature: Separate Docker frontend port from local Vite dev server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       VITE_API_URL: http://localhost:8000/api/v1
     ports:
-      - "5174:5174"
+      - "15173:5173"
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -90,13 +90,9 @@ start_frontend() {
     
     # Check if frontend is running
     if is_port_in_use 5173; then
-        print_info "✓ Frontend is running at http://localhost:5173"
-    elif is_port_in_use 5174; then
-        print_info "✓ Frontend is running at http://localhost:5174"
-    elif is_port_in_use 5175; then
-        print_info "✓ Frontend is running at http://localhost:5175"
+        print_info "✓ Local Vite dev server is running at http://localhost:5173"
     else
-        print_warn "Frontend may still be starting up. Check logs/frontend.log"
+        print_warn "Local Vite dev server may still be starting up. Check logs/frontend.log"
     fi
 }
 
@@ -138,15 +134,18 @@ show_status() {
         print_warn "✗ Database (PostgreSQL): Not running"
     fi
     
-    # Frontend status
-    if is_port_in_use 5173; then
-        print_info "✓ Frontend (Vite): Running on http://localhost:5173"
-    elif is_port_in_use 5174; then
-        print_info "✓ Frontend (Vite): Running on http://localhost:5174"
-    elif is_port_in_use 5175; then
-        print_info "✓ Frontend (Vite): Running on http://localhost:5175"
+    # Docker Frontend status
+    if docker-compose ps | grep -q "northwind-frontend.*Up"; then
+        print_info "✓ Frontend (Docker Container): Running on http://localhost:15173"
     else
-        print_warn "✗ Frontend (Vite): Not running"
+        print_warn "✗ Frontend (Docker Container): Not running"
+    fi
+    
+    # Local Vite Frontend status
+    if is_port_in_use 5173; then
+        print_info "✓ Frontend (Local Vite Dev): Running on http://localhost:5173"
+    else
+        print_warn "✗ Frontend (Local Vite Dev): Not running"
     fi
     
     echo ""


### PR DESCRIPTION
## Description
Fixes #11

This PR separates the Docker frontend container port from the local Vite dev server port, allowing both to run simultaneously without conflicts.

## Changes Made

### docker-compose.yml
- Changed frontend service port mapping from `5174:5174` to `15173:5173`
- Docker frontend container now accessible at http://localhost:15173
- Container internal port remains 5173 (Vite default)

### scripts/local-dev.sh
**Updated `show_status()` function:**
- Now reports Docker frontend container separately: "Frontend (Docker Container): http://localhost:15173"
- Reports local Vite dev server separately: "Frontend (Local Vite Dev): http://localhost:5173"
- Clear distinction between the two services

**Updated `start_frontend()` function:**
- Simplified startup messages
- Only checks for local Vite dev server on port 5173
- Clearer messaging about which service is starting

## Benefits
- ✅ No port conflicts between Docker and local development
- ✅ Clear visibility of which frontend service is running
- ✅ Can run both Docker container and local Vite dev server simultaneously
- ✅ Easier to understand which service to use for development

## Port Mapping Summary
| Service | Port | URL |
|---------|------|-----|
| Backend (Docker) | 8000 | http://localhost:8000 |
| Database (Docker) | 5432 | localhost:5432 |
| Frontend (Docker Container) | 15173 | http://localhost:15173 |
| Frontend (Local Vite Dev) | 5173 | http://localhost:5173 |

## Testing
- [x] Changes compile without errors
- [ ] Start Docker services and verify frontend accessible on port 15173
- [ ] Start local Vite dev server and verify accessible on port 5173
- [ ] Run `./scripts/local-dev.sh status` and verify both services reported correctly
- [ ] Verify no port conflicts when both services run

## Related Issues
Closes #11